### PR TITLE
Fix bugs with command-check in PlayerListener

### DIFF
--- a/src/main/java/red/kalos/costcommand/listener/PlayerListener.java
+++ b/src/main/java/red/kalos/costcommand/listener/PlayerListener.java
@@ -13,31 +13,40 @@ import red.kalos.costcommand.util.api.ColorParser;
 
 public class PlayerListener implements Listener {
 
-    @EventHandler
-    public void PlayerCommandPreprocessEvent(PlayerCommandPreprocessEvent event){
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
+        if (!event.getMessage().startsWith("/")) return;
+
+        String msg = event.getMessage().replace("/", "");
         Player player = event.getPlayer();
-        System.out.println(event.getMessage());
-        for (CostCommand costCommand: CostCommandManager.getCostCommandList()) {
-            if (event.getMessage().contains(costCommand.getCommand())){
-                if (Main.getEconomy().getBalance(player)>=costCommand.getCost()){
-                    if (CostCommandManager.setPlayerData(event.getPlayer(), costCommand)){
-                        Main.getEconomy().withdrawPlayer(player,costCommand.getCost());
-                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(),Main.getInstance().getConfig().getString("command")
-                                .replace("%player%",player.getName())
-                                .replace("%cost%",String.valueOf(costCommand.getCost()))
-                        );
-                    }else {
-                        player.sendMessage(ColorParser.parse("&8[&c&l!&8] &7很抱歉，您使用该指令的次数上限了。"));
-                        player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO,1,1);
-                        event.setCancelled(true);
-                    }
-                }else {
-                    player.sendMessage(ColorParser.parse("&8[&c&l!&8] &7很抱歉，您余额不足，您还需要 &c"+(costCommand.getCost()-Main.getEconomy().getBalance(player))+" &7金钱才能使用这个指令。"));
-                    player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO,1,1);
+
+        String[] args = msg.split(" ");
+        if (args.length <= 0) return;
+
+        for (CostCommand costCommand : CostCommandManager.getCostCommandList()) {
+            if (!args[0].equalsIgnoreCase(costCommand.getCommand()))
+                continue;
+
+            if (Main.getEconomy().getBalance(player) >= costCommand.getCost()) {
+                if (CostCommandManager.setPlayerData(event.getPlayer(), costCommand)) {
+                    Main.getEconomy().withdrawPlayer(player, costCommand.getCost());
+                    Bukkit.dispatchCommand(
+                            Bukkit.getConsoleSender(),
+                            Main.getInstance().getConfig().getString("command")
+                                    .replace("%player%", player.getName())
+                                    .replace("%cost%", String.valueOf(costCommand.getCost()))
+                    );
+                } else {
+                    player.sendMessage(ColorParser.parse("&8[&c&l!&8] &7很抱歉，您使用该指令的次数上限了。"));
+                    player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
                     event.setCancelled(true);
                 }
-
+            } else {
+                player.sendMessage(ColorParser.parse("&8[&c&l!&8] &7很抱歉，您余额不足，您还需要 &c" + (costCommand.getCost() - Main.getEconomy().getBalance(player)) + " &7金钱才能使用这个指令。"));
+                player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
+                event.setCancelled(true);
             }
+
         }
     }
 }


### PR DESCRIPTION
Fix bugs:
1. Commands, such as "TAB","tAB", "taB", doesn't be checked, because characters cases doesn't be noticed.
2. Commands contains with other cost-command as substring will be check, too, although they are different commands.